### PR TITLE
Updated README instructions to make new revisions visible to shogun repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ Usually there is no need to checkout this module separately.  Just
 checkout (or clone) the source repository https://github.com/shogun-toolbox/shogun
 and issue ```git submodule update --init``` in the root directory.
 Then, fetch the data files by simply doing ```git submodule update```.
+
+Every new revision must be committed in shogun as well.  After merging
+new commits to `shogun-date`, you need to commit the new revision to
+the `shogun` repository:
+
+   `cd data && git checkout master && cd ..`
+   `git add data && git commit -m "updating revision of data submodule"`


### PR DESCRIPTION
We always forget to update `shogun/data` - add this information to the README and hope will happen less often.
