### PR TITLE
Change incorrect int types to float64 types

### DIFF
--- a/testsuite/meta/binary_classifier/kernel_svm.dat
+++ b/testsuite/meta/binary_classifier/kernel_svm.dat
@@ -1,6 +1,6 @@
 <<_SHOGUN_SERIALIZABLE_ASCII_FILE_V_00_>>
-array Vector<SGSerializable*> 6 ({WrappedBasic int32 [
-value int32 1
+array Vector<SGSerializable*> 6 ({WrappedBasic float64 [
+value float64 1
 ]}{WrappedBasic float64 [
 value float64 0.001
 ]}{WrappedSGVector float64 [

--- a/testsuite/meta/binary_classifier/linear_svm.dat
+++ b/testsuite/meta/binary_classifier/linear_svm.dat
@@ -1,6 +1,6 @@
 <<_SHOGUN_SERIALIZABLE_ASCII_FILE_V_00_>>
-array Vector<SGSerializable*> 6 ({WrappedBasic int32 [
-value int32 1
+array Vector<SGSerializable*> 6 ({WrappedBasic float64 [
+value float64 1
 ]}{WrappedBasic float64 [
 value float64 0.001
 ]}{WrappedSGVector float64 [

--- a/testsuite/meta/gaussian_processes/gaussian_process_regression.dat
+++ b/testsuite/meta/gaussian_processes/gaussian_process_regression.dat
@@ -1,6 +1,6 @@
 <<_SHOGUN_SERIALIZABLE_ASCII_FILE_V_00_>>
-array Vector<SGSerializable*> 4 ({WrappedBasic int32 [
-value int32 1
+array Vector<SGSerializable*> 4 ({WrappedBasic float64 [
+value float64 1
 ]}{WrappedBasic float64 [
 value float64 0.01455988410195748
 ]}{WrappedBasic float64 [

--- a/testsuite/meta/multiclass_classifier/svm.dat
+++ b/testsuite/meta/multiclass_classifier/svm.dat
@@ -1,6 +1,6 @@
 <<_SHOGUN_SERIALIZABLE_ASCII_FILE_V_00_>>
-array Vector<SGSerializable*> 4 ({WrappedBasic int32 [
-value int32 1
+array Vector<SGSerializable*> 4 ({WrappedBasic float64 [
+value float64 1
 ]}{WrappedBasic float64 [
 value float64 0.0001
 ]}{WrappedBasic float64 [

--- a/testsuite/meta/regression/kernel_ridge_regression.dat
+++ b/testsuite/meta/regression/kernel_ridge_regression.dat
@@ -1,6 +1,6 @@
 <<_SHOGUN_SERIALIZABLE_ASCII_FILE_V_00_>>
-array Vector<SGSerializable*> 5 ({WrappedBasic int32 [
-value int32 1
+array Vector<SGSerializable*> 5 ({WrappedBasic float64 [
+value float64 1
 ]}{WrappedBasic float64 [
 value float64 0.001
 ]}{WrappedSGVector float64 [

--- a/testsuite/meta/regression/support_vector_regression.dat
+++ b/testsuite/meta/regression/support_vector_regression.dat
@@ -1,8 +1,8 @@
 <<_SHOGUN_SERIALIZABLE_ASCII_FILE_V_00_>>
-array Vector<SGSerializable*> 6 ({WrappedBasic int32 [
-value int32 1
-]}{WrappedBasic int32 [
-value int32 1
+array Vector<SGSerializable*> 6 ({WrappedBasic float64 [
+value float64 1
+]}{WrappedBasic float64 [
+value float64 1
 ]}{WrappedBasic float64 [
 value float64 0.1
 ]}{WrappedSGVector float64 [


### PR DESCRIPTION
Fixes wrong types in integration tests. Makes ~~shogun-toolbox/shogun#3410~~ shogun-toolbox/shogun#3413 pass the tests