### PR TITLE
Fix ecoc random data

### DIFF
--- a/testsuite/meta/multiclass_classifier/multiclass_ecoc_random.dat
+++ b/testsuite/meta/multiclass_classifier/multiclass_ecoc_random.dat
@@ -1,8 +1,8 @@
 <<_SHOGUN_SERIALIZABLE_ASCII_FILE_V_00_>>
 array Vector<SGSerializable*> 2 ({WrappedBasic float64 [
-value float64 0.55
+value float64 0.5
 ]}{WrappedSGVector float64 [
-value SGVector<float64> 20 ({0}{1}{1}{1}{1}{0}{0}{1}{0}{1}{1}{1}{1}{2}{1}{1}{1}{0}{1}{2})
+value SGVector<float64> 20 ({0}{1}{2}{1}{1}{0}{0}{1}{0}{1}{1}{1}{2}{2}{1}{1}{1}{0}{1}{0})
 ]})
 num_elements int32 2
 resize_granularity int32 128


### PR DESCRIPTION
Slightly confused about why this one suddenly fails the integration test. Anyways, this should fix it.