### PR TITLE
sgd svm data

### DIFF
--- a/testsuite/meta/binary_classifier/sgd_svm.dat
+++ b/testsuite/meta/binary_classifier/sgd_svm.dat
@@ -1,0 +1,20 @@
+<<_SHOGUN_SERIALIZABLE_ASCII_FILE_V_00_>>
+array Vector<SGSerializable*> 7 ({WrappedBasic float64 [
+value float64 1
+]}{WrappedBasic int32 [
+value int32 5
+]}{WrappedBasic int32 [
+value int32 1
+]}{WrappedSGVector float64 [
+value SGVector<float64> 2 ({0.6988634714088722}{0.6639011564345909})
+]}{WrappedBasic float64 [
+value float64 -0.1836621259685584
+]}{WrappedBasic float64 [
+value float64 1
+]}{WrappedSGVector float64 [
+value SGVector<float64> 20 ({1}{1}{-1}{1}{1}{-1}{1}{1}{1}{-1}{-1}{1}{1}{-1}{1}{1}{1}{-1}{-1}{-1})
+]})
+num_elements int32 7
+resize_granularity int32 128
+use_sg_malloc bool t
+free_array bool t


### PR DESCRIPTION
Data for sgd svm.
@karlnapf  review.
I am writing integration test data for [this](https://github.com/shogun-toolbox/shogun/blob/develop/examples/undocumented/python_modular/classifier_svmsgd_modular.py)