### PR TITLE
Fix integration testing data for linear ridge regression

### DIFF
--- a/testsuite/meta/evaluation/cross_validation.dat
+++ b/testsuite/meta/evaluation/cross_validation.dat
@@ -12,7 +12,7 @@ value float64 0.95
 ]}{Serializable float64 [
 value float64 0.001
 ]}{Serializable float64 [
-value float64 471.4097298936205
+value float64 7.737400293930307
 ]})
 resize_granularity int32 128
 use_sg_malloc bool t

--- a/testsuite/meta/regression/linear_ridge_regression.dat
+++ b/testsuite/meta/regression/linear_ridge_regression.dat
@@ -1,16 +1,16 @@
 <<_SHOGUN_SERIALIZABLE_ASCII_FILE_V_00_>>
 array Vector<SGSerializable*> 6 ({Serializable float64 [
-value float64 0
+value float64 1.67901688938224
 ]}{VectorSerializable float64 [
-value SGVector<float64> 1 ({0})
+value SGVector<float64> 1 ({3.071725989584406})
 ]}{Serializable float64 [
 value float64 0.1
 ]}{Serializable float64 [
-value float64 471.4097298936205
+value float64 7.737400293930307
 ]}{VectorSerializable float64 [
-value SGVector<float64> 5 ({0}{0}{0}{0}{0})
+value SGVector<float64> 5 ({21.6497048298623}{19.22438429795561}{27.80777458518325}{15.25056343558564}{17.02323474155812})
 ]}{VectorSerializable float64 [
-value SGVector<float64> 5 ({0.1}{0.1}{0.1}{0.1}{0.1})
+value SGVector<float64> 5 ({21.66445978459152}{19.04558520045495}{28.31397771732908}{14.75463135684449}{16.66877168104726})
 ]})
 resize_granularity int32 128
 use_sg_malloc bool t


### PR DESCRIPTION
Fix integration testing data for linear ridge regression, after fixing SGVector implementation [#4497](https://github.com/shogun-toolbox/shogun/issues/4497)